### PR TITLE
Add skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Paseo plugins add native workspace panels, composer pills, Command Center items,
 
 *Plugins that add panels to workspace tabs or the explorer.*
 
-<!-- Add workspace panel plugins here. -->
+- [skills](https://github.com/gpambrozio/paseo-plugins/tree/main/skills) - Lists the skills and commands an agent session can run, shows where each one comes from, renders its `SKILL.md`, and invokes it on the live session. Claude and Codex sessions get their skill files read off the daemon's filesystem; every other provider shows what the running session reports. Install with `paseo plugin add gpambrozio/paseo-plugins --path skills`.
 
 ## Themes
 


### PR DESCRIPTION
## Plugin

- Name: skills
- Repository: https://github.com/gpambrozio/paseo-plugins (monorepo; this entry is the `skills/` directory)

## What it does

A **Skills** pill above an agent's composer (badge-counting what it found) opens a per-agent
workspace panel listing every skill and command that session can run, grouped by where it came
from: project, repository, personal, and plugin directories, plus the entries the session itself
reports. Picking one shows its rendered `SKILL.md` with an arguments field, and **Invoke** sends
`/<name> <args>` to that live agent. Same panel from the Command Center.

Discovery scans `~/.claude`, `~/.agents`, `~/.codex`, `/etc/codex`, and every directory from the
agent's cwd up to the repo root, because the source and body need the `SKILL.md` file itself.
Entries bundled into an agent binary live on no scannable path, so those come from `agent.commands()`
and get their own sections.

## Why it belongs

Paseo can start an agent anywhere, but nothing in the app tells you which skills that particular
session can actually reach — that depends on the provider, the cwd, and four or five directories
above it. This answers that in one tap and lets you run the skill without typing the slash command,
including on a phone.

Provider-aware rather than Claude-only: `claude` and `codex` resolve off disk, and other providers
still list what the session reports rather than showing an error.

### How I verified installation

Daemon and CLI 0.7.0-beta.2, macOS. Installed straight from Git with no package manager step:

```
$ paseo plugin add gpambrozio/paseo-plugins --path skills --id skills-gitcheck
PLUGIN            STATUS   ENABLED  DIRECTORY
skills-gitcheck   running  yes      ~/.paseo/plugins/skills-gitcheck/.../checkout/skills

$ paseo plugin logs skills-gitcheck
stdout  [paseo] Loading plugin
stdout  [paseo] Plugin ready
```

Then opened the panel on a live Claude session and invoked a skill. I used `--id` only so the test
install would not collide with the copy I develop against; the default id is `skills`. Removed
afterwards with `paseo plugin remove`.

The plugin ships source only. Everything it imports at runtime is host-provided —
`@getpaseo/plugin`, `react`, `react-native`, `@tanstack/react-query`, `zod` — plus `node:` builtins
in the server half. `npm install` is for typechecking and tests, not for installing.

### Notes on the entry

- Public repo, MIT licensed. The [README](https://github.com/gpambrozio/paseo-plugins/tree/main/skills)
  covers what it does, what it reads (the daemon machine's filesystem, read-only — it never writes
  to `~/.claude`), what it changes (it sends a prompt to your running agent), the trust model, and
  known limits. [`docs/design.md`](https://github.com/gpambrozio/paseo-plugins/blob/main/skills/docs/design.md)
  records why discovery is shaped this way.
- No minimum version stated: it loads on 0.5.0-beta and newer, and the built-in command sections
  need `agent.commands()` from 0.7.0-beta.2, the current release. On an older daemon those sections
  are feature-detected away rather than erroring.
- No platform limit: desktop, web, iOS, and Android. The client bundle avoids async arrow functions
  so Hermes's `eval` compiler doesn't drop them.

- The entry links the `skills/` folder rather than the repo root, since the repo holds two plugins.
  Happy to point it at the root and drop the install line if you'd rather entries stayed to the exact
  one-line format.

## Checklist

- [x] This pull request adds or updates one plugin.
- [x] I read and followed [CONTRIBUTING.md](https://github.com/omercnet/awesome-paseo-plugins/blob/main/CONTRIBUTING.md).
- [x] I installed it successfully with `paseo plugin add` without install scripts.
- [x] Its README explains behavior, state access, security implications, and known limitations.
- [x] The entry is in the correct category and alphabetical position.
- [x] The entry uses the required format and a factual description ending with a period.
- [x] I noted platform limits and the minimum Paseo daemon version where relevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
