### PR TITLE
Add github-board

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Paseo plugins add native workspace panels, composer pills, Command Center items,
 ## Monitoring and orchestration
 
 - [agent-monitor](https://github.com/omercnet/paseo-agent-monitor) - One roster for every agent on a daemon. Triage buckets (Attention / Running / Idle / Closed), project-first grouping, text filter, live diff stats, and one-tap archive sweep. Answers "which of my 38 agents needs me right now" without walking the workspace tree. Web and desktop.
+- [github-board](https://github.com/gpambrozio/paseo-plugins/tree/main/github-board) - A sidebar surface with four columns — issues, draft PRs, open PRs, and discussions — covering what you authored plus what is open on the repositories you own. Cards carry CI check counts, editable labels, and a "Send to chat" button that creates a workspace on the project matching that repository and starts an agent on the card. Requires `gh` installed and authenticated on the daemon machine. Install with `paseo plugin add gpambrozio/paseo-plugins --path github-board`.
 
 ## Workspace panels
 


### PR DESCRIPTION
## Plugin

- Name: github-board
- Repository: https://github.com/gpambrozio/paseo-plugins/tree/main/github-board (monorepo; this entry is the `github-board/` directory)

## What it does

A global **GitHub** sidebar surface with four columns: Issues, Draft PRs, Open PRs, Discussions.
Each column runs two searches — `author:<login>` and `user:<login>` — so work other people opened on
your own repositories shows up alongside your own, with the author named on the card.

- An issue that already has an open pull request against it collapses into that PR's card as an
  `Issue #123` pill, so one piece of work is one card.
- Open PR cards lead with the check rollup on the head commit — passed, failed, still running —
  fetched in a separate `gh` call so a token that cannot read checks costs you the pills rather than
  the whole column.
- Right-click (long-press on a phone) a card to add or remove that repository's labels inline.
- **Send to chat** opens Paseo's own New workspace dialog — local or worktree, provider, model,
  thinking level, permission mode — pre-filled with a per-column, per-project prompt template, then
  creates the workspace on the project whose git remote matches the card's repository, starts the
  agent, sends the message, and opens it.
- Empty columns drop off the board; a column that *failed* stays and shows its error.

## Why it belongs

It closes the loop between "here is something to work on" and "an agent is working on it" without
leaving Paseo: the board is the triage view, and the agent it starts lands in the right project with
the right first message. Everything runs through `gh` on the daemon, so there is no token to
configure in the app and the mobile client gets the same board as the desktop.

It is deliberately cheap on the API — three `gh api graphql` calls per refresh for four columns, plus
one for checks — with a five-minute cache on both sides so a workspace switch repaints instantly
instead of re-querying.

### How I verified installation

Daemon and CLI 0.7.0-beta.2, macOS. Installed straight from Git with no package manager step:

```
$ paseo plugin add gpambrozio/paseo-plugins --path github-board --id github-board-gitcheck
PLUGIN                  STATUS   ENABLED  DIRECTORY
github-board-gitcheck   running  yes      ~/.paseo/plugins/github-board-gitcheck/.../checkout/github-board

$ paseo plugin logs github-board-gitcheck
stdout  [paseo] Loading plugin
stdout  [paseo] Plugin ready
```

Then opened the surface, loaded all four columns against my own account, and used it daily from the
directory install. I used `--id` only so the test install would not collide with the copy I develop
against; the default id is `github-board`. Removed afterwards with `paseo plugin remove`.

Source only, no build step: `@getpaseo/plugin` is host-provided, as are `react`, `react-native` and
`zod`; the server half uses `node:` builtins and shells out to `gh`. `npm install` is for
typechecking, not installing.

### State it reads and changes, for the security note

- Runs `gh` on the daemon machine as whoever `gh` is authenticated as — reads issues, PRs,
  discussions, labels and check runs.
- Writes labels back to GitHub when you edit them, which needs write access to that repository.
- Creates workspaces, starts agents, and sends prompts through the host API when you use Send to chat.
- Persists your login, hidden repositories, prompt templates and launch defaults to
  `$PASEO_HOME/plugins/github-board/settings.json`. No token is ever stored by the plugin.

### Notes on the entry

- Public repo, MIT licensed. The
  [README](https://github.com/gpambrozio/paseo-plugins/tree/main/github-board) documents every query
  it runs, the caching, the trust model, and a Known limits section — including that nothing you
  merely participated in appears, and that `user:<login>` does not cover organisations you don't own.
- No minimum version in the entry: it loads on 0.5.0-beta and newer, and the project chips and Send
  to chat need `paseo.projects.list()` from 0.5.2 — both older than the current release.
- No platform limit: desktop, web, iOS and Android. External links route through the desktop opener
  and fall back to `Linking` elsewhere, and the client bundle avoids async arrows for Hermes.
- The entry links the `github-board/` folder rather than the repo root, since the repo holds two
  plugins. The `gh` requirement is in the entry because it is a real prerequisite on the daemon
  machine, not on the device running the app — happy to trim either if you'd rather entries stayed
  shorter.

## Checklist

- [x] This pull request adds or updates one plugin.
- [x] I read and followed [CONTRIBUTING.md](https://github.com/omercnet/awesome-paseo-plugins/blob/main/CONTRIBUTING.md).
- [x] I installed it successfully with `paseo plugin add` without install scripts.
- [x] Its README explains behavior, state access, security implications, and known limitations.
- [x] The entry is in the correct category and alphabetical position.
- [x] The entry uses the required format and a factual description ending with a period.
- [x] I noted platform limits and the minimum Paseo daemon version where relevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
