### PR TITLE
Add PR Radar

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Paseo plugins add native workspace panels, composer pills, Command Center items,
 
 - [agent-monitor](https://github.com/omercnet/paseo-agent-monitor) - One roster for every agent on a daemon. Triage buckets (Attention / Running / Idle / Closed), project-first grouping, text filter, live diff stats, and one-tap archive sweep. Answers "which of my 38 agents needs me right now" without walking the workspace tree. Web and desktop.
 - [github-board](https://github.com/gpambrozio/paseo-plugins/tree/main/github-board) - A sidebar surface with four columns — issues, draft PRs, open PRs, and discussions — covering what you authored plus what is open on the repositories you own. Cards carry CI check counts, editable labels, and a "Send to chat" button that creates a workspace on the project matching that repository and starts an agent on the card. Requires `gh` installed and authenticated on the daemon machine. Install with `paseo plugin add gpambrozio/paseo-plugins --path github-board`.
+- [pr-radar](https://github.com/omercnet/paseo-pr-radar) - Turns pull requests linked to active workspaces into a viewer-aware delivery queue grouped by needs you, being handled, waiting externally, and ready, with actions to prompt an existing agent or start one; requires `gh` installed and authenticated on the daemon machine and Paseo 0.6 or later.
 
 ## Workspace panels
 


### PR DESCRIPTION
## Plugin

- Name: PR Radar
- Repository: https://github.com/omercnet/paseo-pr-radar

## Why it belongs

PR Radar turns pull requests linked to active Paseo workspaces into a viewer-aware delivery queue, grouping work by who needs to act and offering direct actions for existing or new agents. I verified the repository installs directly from Git with `paseo plugin add omercnet/paseo-pr-radar --id pr-radar-list-verification`; the temporary installation reached `running` with no error. I also ran `npx --yes awesome-lint@2.3.0`.

## Checklist

- [x] This pull request adds or updates one plugin.
- [x] I read and followed [CONTRIBUTING.md](https://github.com/omercnet/awesome-paseo-plugins/blob/main/CONTRIBUTING.md).
- [x] I installed it successfully with `paseo plugin add` without install scripts.
- [x] Its README explains behavior, state access, security implications, and known limitations.
- [x] The entry is in the correct category and alphabetical position.
- [x] The entry uses the required format and a factual description ending with a period.
- [x] I noted platform limits and the minimum Paseo daemon version where relevant.