### PR TITLE
feat(plugins): add mcowger plugin links

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ Paseo plugins add native workspace panels, composer pills, Command Center items,
 
 *Plugins that add panels to workspace tabs or the explorer.*
 
+- [opencode-session-overview](https://github.com/mcowger/paseo-plugins/tree/main/opencode-session-overview) - Adds an agent-scoped activity pane for OpenCode sessions with session details, usage, context, tasks, loaded skills and commands, workspace metadata, and observed subagents. Requires Paseo 0.7.0-beta.2 or later.
+- [pi-tasks-timeline](https://github.com/mcowger/paseo-plugins/tree/main/pi-tasks-timeline) - Keeps Pi task lists visible in Paseo timelines and workspace or explorer panels, with a composer pill for active tasks.
 - [skills](https://github.com/gpambrozio/paseo-plugins/tree/main/skills) - Lists the skills and commands an agent session can run, shows where each one comes from, renders its `SKILL.md`, and invokes it on the live session. Claude and Codex sessions get their skill files read off the daemon's filesystem; every other provider shows what the running session reports. Install with `paseo plugin add gpambrozio/paseo-plugins --path skills`.
+- [subagent-activity](https://github.com/mcowger/paseo-plugins/tree/main/subagent-activity) - Adds an agent-scoped activity pane for monitoring managed Paseo descendants and provider-native subagent activity. Requires Paseo 0.7.0-beta.2 or later.
 
 ## Themes
 


### PR DESCRIPTION
## Plugin

- Names: Pi tasks timeline, OpenCode session overview, and Subagent activity
- Repository: https://github.com/mcowger/paseo-plugins

## Why it belongs

These three related plugins add complementary visibility for agent work in Paseo: Pi task timelines, OpenCode session details, and managed or provider-native subagent activity. They are listed under Workspace panels in alphabetical order, with direct links to their monorepo plugin directories and the minimum Paseo version noted where the plugin README specifies one.

## Checklist

- [ ] This pull request adds or updates one plugin. This draft intentionally groups the three related plugins above.
- [x] I read and followed [CONTRIBUTING.md](https://github.com/omercnet/awesome-paseo-plugins/blob/main/CONTRIBUTING.md).
- [ ] I installed them successfully with `paseo plugin add` without install scripts.
- [x] Their READMEs explain behavior, state access, security implications, and known limitations.
- [x] I understand the public plugin source and deterministic scanner findings are sent to the configured model provider for automated security review and contain no secrets, personal information, or confidential material.
- [x] The entries are in the correct category and alphabetical position.
- [x] The entries use the required format and factual descriptions ending with periods.
- [x] I noted the minimum Paseo daemon version where relevant.

## Verification

- `npm test`
- `npm run check:scripts`
- `npx --yes awesome-lint@2.3.0 https://github.com/omercnet/awesome-paseo-plugins`
