### PR TITLE
feat(plugins): add subagent activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Paseo plugins add native workspace panels, composer pills, Command Center items,
 *Plugins that add panels to workspace tabs or the explorer.*
 
 - [skills](https://github.com/gpambrozio/paseo-plugins/tree/main/skills) - Lists the skills and commands an agent session can run, shows where each one comes from, renders its `SKILL.md`, and invokes it on the live session. Claude and Codex sessions get their skill files read off the daemon's filesystem; every other provider shows what the running session reports. Install with `paseo plugin add gpambrozio/paseo-plugins --path skills`.
+- [subagent-activity](https://github.com/mcowger/paseo-plugins/tree/main/subagent-activity) - Adds an agent-scoped activity pane for monitoring managed Paseo descendants and provider-native subagent activity. Requires Paseo 0.7.0-beta.2 or later.
 
 ## Themes
 


### PR DESCRIPTION
## Plugin

- Name: Subagent activity
- Repository: https://github.com/mcowger/paseo-plugins/tree/main/subagent-activity

## Why it belongs

This plugin adds an agent-scoped activity pane for monitoring managed Paseo descendants and provider-native subagent activity. It separates managed child-agent data from best-effort native activity and presents lifecycle, usage, tool-call, and timeline information in a focused workspace panel.

## Checklist

- [x] This pull request adds or updates one plugin.
- [x] I read and followed [CONTRIBUTING.md](https://github.com/omercnet/awesome-paseo-plugins/blob/main/CONTRIBUTING.md).
- [x] I installed it successfully with `paseo plugin add` without install scripts.
- [x] Its README explains behavior, state access, security implications, and known limitations.
- [x] I understand the public plugin source and deterministic scanner findings are sent to the configured model provider for automated security review and contain no secrets, personal information, or confidential material.
- [x] The entry is in the correct category and alphabetical position.
- [x] The entry uses the required format and a factual description ending with a period.
- [x] I noted platform limits and the minimum Paseo daemon version where relevant.

## Verification

- `npm test`
- `npm run check:scripts`
- `npx --yes awesome-lint@2.3.0 https://github.com/omercnet/awesome-paseo-plugins`
