### PR TITLE
Add defer

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Paseo plugins add native workspace panels, composer pills, Command Center items,
 
 *Plugins that add daemon-side behavior: schedulers, webhooks, notifications, integrations.*
 
-<!-- Add daemon and automation plugins here. -->
+- [defer](https://github.com/tomgrin10/paseo-defer) - Queues a message for an agent and delivers it after a relative delay, at a chosen local time, or when the Claude rolling usage window resets, holding delivery until the target session goes idle so the message arrives as a new turn instead of steering an active one. A composer pill shows what is waiting, queued messages stay editable until delivery starts, and the daemon-side queue survives plugin reloads, restarts, and reconnecting clients. Borrows Paseo's own daemon client at runtime to read provider usage, which the public plugin SDK does not expose. Requires Paseo 0.7 or later.
 
 ## Composer and attachments
 


### PR DESCRIPTION
## Plugin

- Name: defer
- Repository: https://github.com/tomgrin10/paseo-defer

## Why it belongs

Defer fills the gap between "message the agent now" and "remember to message it later". It queues a message and delivers it after a relative delay, at a chosen local time, or when the Claude rolling usage window resets — the last being the case that motivated it: parking follow-up work so it lands the moment quota returns, instead of spending a turn against a throttled window.

Delivery waits for the target session to go idle, so a queued message arrives as a new turn rather than steering one mid-flight. A composer pill shows what is waiting inline, queued messages stay editable until delivery starts, and the queue lives on the daemon, so it survives plugin reloads, restarts, and any client that reconnects.

It opens the currently empty **Daemon and automation** category as a scheduler, which is the first behaviour that section's scope line names. It does also contribute a composer pill and a workspace panel, but those are the interface to the scheduler rather than the substance, so a single entry there seemed right — happy to move it if you read the categories differently.

## How I verified it

- `paseo plugin add tomgrin10/paseo-defer` on Paseo 0.7.0, from a clean state with no local checkout — no package manager runs and the repository ships no install script.
- Separately reproduced the daemon's own build (`filterEntrypoint` plus the client and server esbuild targets from `packages/server/src/server/plugins/compiler.ts`) against a bare `git clone` with no `node_modules`; both bundles compile. The repository keeps that as a committed regression check (`check-gitinstall.mjs`) so a stray static import cannot silently break Git installs again.
- Exercised all three trigger kinds, plus edit and cancel on a pending message, and a plugin reload with a message still queued.

One thing worth flagging for review: Defer reads the rolling usage window through `provider.usage.list`, which the public plugin SDK does not expose, so it borrows Paseo's own daemon client from the host at runtime rather than bundling a copy. That is what keeps it installable without a package manager and pins it to the daemon's protocol version, but it is an internal API, and the plugin's README says so under Security and data. MIT licensed; queued message text is stored under `$PASEO_HOME/plugin-data/defer/`.

## Checklist

- [x] This pull request adds or updates one plugin.
- [x] I read and followed [CONTRIBUTING.md](https://github.com/omercnet/awesome-paseo-plugins/blob/main/CONTRIBUTING.md).
- [x] I installed it successfully with `paseo plugin add` without install scripts.
- [x] Its README explains behavior, state access, security implications, and known limitations.
- [x] I understand the public plugin source and deterministic scanner findings are sent to the configured model provider for automated security review and contain no secrets, personal information, or confidential material.
- [x] The entry is in the correct category and alphabetical position.
- [x] The entry uses the required format and a factual description ending with a period.
- [x] I noted platform limits and the minimum Paseo daemon version where relevant.
