### PR TITLE
fix: repair required pull request checks

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -3,9 +3,6 @@ name: Check links
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "**/*.md"
-      - ".github/workflows/links.yml"
   push:
     branches: [main]
     paths:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,9 +3,6 @@ name: Lint
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "**/*.md"
-      - ".github/workflows/lint.yml"
   push:
     branches: [main]
     paths:

--- a/.github/workflows/plugin-security.yml
+++ b/.github/workflows/plugin-security.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-      issues: write
+      pull-requests: write
     steps:
       - name: Check out trusted scanner
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary

- grant the security scan job `pull-requests: write` so fork-origin `pull_request_target` runs can publish their report
- run the required `awesome-lint` and `links` checks on every pull request
- retain Markdown-only path filters for pushes while preventing required PR checks from remaining permanently pending

## Root causes

1. Scan report publication received HTTP 403 because the job requested issue mutation permission while mutating a pull request.
2. The repository ruleset requires `awesome-lint` and `links`, but both workflows filtered pull requests to Markdown changes. Non-Markdown pull requests therefore waited forever for checks that GitHub never scheduled.

Deterministic plugin-policy findings remain blocking by design.

## Verification

- `npm test` (19 passed)
- `npm run check:scripts`
- `zizmor .github/workflows/plugin-security.yml .github/workflows/lint.yml .github/workflows/links.yml` (no findings; existing inline suppressions only)
- `actionlint -shellcheck= .github/workflows/lint.yml .github/workflows/links.yml`