### PR TITLE
Shorten the defer description

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Paseo plugins add native workspace panels, composer pills, Command Center items,
 
 *Plugins that add daemon-side behavior: schedulers, webhooks, notifications, integrations.*
 
-- [defer](https://github.com/tomgrin10/paseo-defer) - Queues a message for an agent and delivers it after a relative delay, at a chosen local time, or when the Claude rolling usage window resets, holding delivery until the target session goes idle so the message arrives as a new turn instead of steering an active one. A composer pill shows what is waiting, queued messages stay editable until delivery starts, and the daemon-side queue survives plugin reloads, restarts, and reconnecting clients. Borrows Paseo's own daemon client at runtime to read provider usage, which the public plugin SDK does not expose. Requires Paseo 0.7 or later.
+- [defer](https://github.com/tomgrin10/paseo-defer) - Queues a message for an agent and delivers it after a delay, at a chosen local time, or when the Claude usage window resets, waiting for the session to go idle so the message starts a new turn. Requires Paseo 0.7 or later.
 
 ## Composer and attachments
 


### PR DESCRIPTION
## What

Trims the `defer` entry from four sentences (100 words, the longest in the list) to a single factual sentence plus its minimum version.

**Before**

> Queues a message for an agent and delivers it after a relative delay, at a chosen local time, or when the Claude rolling usage window resets, holding delivery until the target session goes idle so the message arrives as a new turn instead of steering an active one. A composer pill shows what is waiting, queued messages stay editable until delivery starts, and the daemon-side queue survives plugin reloads, restarts, and reconnecting clients. Borrows Paseo's own daemon client at runtime to read provider usage, which the public plugin SDK does not expose. Requires Paseo 0.7 or later.

**After**

> Queues a message for an agent and delivers it after a delay, at a chosen local time, or when the Claude usage window resets, waiting for the session to go idle so the message starts a new turn. Requires Paseo 0.7 or later.

## Why

`CONTRIBUTING.md` specifies `Factual one-sentence description.` — I overshot that in #11. This keeps what distinguishes the plugin (the three delivery triggers, and waiting for idle so the message starts a new turn rather than steering an active one) and moves the composer pill, queue durability, and daemon-client details to the plugin's own README, where the contribution guide already requires them.

No entry added, removed, or recategorized; the link is unchanged.

## Verification

- `npx awesome-lint@2.3.0` passes locally.
- Branched off current `main` (`07bd496`), so no conflict with the merged #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)