### PR TITLE
Add send-to-paseo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Paseo plugins add native workspace panels, composer pills, Command Center items,
 *Plugins that add daemon-side behavior: schedulers, webhooks, notifications, integrations.*
 
 - [defer](https://github.com/tomgrin10/paseo-defer) - Queues a message for an agent and delivers it after a relative delay, at a chosen local time, or when the Claude rolling usage window resets, holding delivery until the target session goes idle so the message arrives as a new turn instead of steering an active one. A composer pill shows what is waiting, queued messages stay editable until delivery starts, and the daemon-side queue survives plugin reloads, restarts, and reconnecting clients. Borrows Paseo's own daemon client at runtime to read provider usage, which the public plugin SDK does not expose. Requires Paseo 0.7 or later.
+- [send-to-paseo](https://github.com/tomgrin10/send-to-paseo/tree/main/plugin) - A Chrome extension and plugin that send a message to Paseo straight from a GitHub or Graphite pull request page. Starts a new agent in the workspace that belongs to that PR, or creates the workspace when you don't have one.
 
 ## Composer and attachments
 


### PR DESCRIPTION
## Plugin

- Name: send-to-paseo
- Repository: https://github.com/tomgrin10/send-to-paseo/tree/main/plugin

## Why it belongs

It closes the gap between reading a pull request and working on it. Today that means finding the
right workspace in Paseo, or creating one and checking out the PR by hand. This plugin resolves the
PR to the workspace that owns it and starts a new agent there from the page you are already on.

The resolution is the interesting part, and it is deliberately conservative: candidates are ranked
(exact branch match, then a member of the same stack, then same project) and the composer always
shows the target it picked plus every alternative, with a note when a worktree is on a different
branch. It never silently creates a workspace and never steers a running agent — every send starts a
new one. Stacked PRs resolve to the one workspace you already have, including when the branch that
worktree is parked on has already merged.

The daemon side is a loopback-only HTTP bridge (`127.0.0.1:7788`) behind a bearer token, speaking a
frozen contract so the browser extension never touches the Paseo daemon or its credentials. It
reaches Paseo only through the SDK. `plugin/README.md` documents the endpoints, the resolution
ladder, the requirements table (`git` required, `gh` optional and what degrades without it), the
security model and the known limitations.

The browser half is a separate manual step: an unpacked Chrome MV3 extension from the repo's release
zip, not something the plugin installs. Worth knowing before trying it. It is MIT licensed.

How I verified installation: I installed the published commit from GitHub with
`paseo plugin add tomgrin10/send-to-paseo --path plugin` under a throwaway install ID on a 0.7.0
daemon, with no packages installed and no install scripts run. It built and reached `running` in
`paseo plugin ls`, its logs were clean, and I removed it again leaving nothing behind. That path
matters here because the plugin imports only host-provided modules (`@getpaseo/client` is
type-only), which a local checkout with `node_modules` present would not prove. I also ran
`npx awesome-lint@2.3.0` and `.github/scripts/plugin-targets.mjs` against the edited README; both
pass, and the entry parses to `path: "plugin"` so the scanner finds `paseo-plugin.json`.

I left the minimum-version note off the entry on purpose: the plugin needs Paseo 0.7.0 or newer,
which the current stable release satisfies, and CONTRIBUTING asks for that note only when a plugin
does not support current stable. Happy to add it if you would rather it be explicit.

Disclosure: I am the plugin's author.

## Checklist

- [x] This pull request adds or updates one plugin.
- [x] I read and followed [CONTRIBUTING.md](https://github.com/omercnet/awesome-paseo-plugins/blob/main/CONTRIBUTING.md).
- [x] I installed it successfully with `paseo plugin add` without install scripts.
- [x] Its README explains behavior, state access, security implications, and known limitations.
- [x] I understand the public plugin source and deterministic scanner findings are sent to the configured model provider for automated security review and contain no secrets, personal information, or confidential material.
- [x] The entry is in the correct category and alphabetical position.
- [x] The entry uses the required format and a factual description ending with a period.
- [x] I noted platform limits and the minimum Paseo daemon version where relevant.
