### PR TITLE
fix(scanner): handle zizmor local paths

### DIFF
--- a/.github/scripts/static-scan.mjs
+++ b/.github/scripts/static-scan.mjs
@@ -116,8 +116,11 @@ export function parseZizmorReport(report, sourceRoot) {
   return report.slice(0, MAX_FINDINGS_PER_TOOL).map((item) => {
     const severity = String(item.determinations?.severity ?? "UNKNOWN").toUpperCase();
     const location = item.locations?.[0] ?? {};
-    const path = location.symbolic?.key ?? location.symbolic?.path ?? location.concrete?.path ?? ".";
-    const row = location.concrete?.location?.row;
+    const symbolicKey = location.symbolic?.key;
+    const path = typeof symbolicKey === "string"
+      ? symbolicKey
+      : symbolicKey?.Local?.verbatim_path ?? location.symbolic?.path ?? location.concrete?.path ?? ".";
+    const row = location.concrete?.location?.start_point?.row ?? location.concrete?.location?.row;
     return finding({
       blocking: severity === "HIGH",
       line: Number.isInteger(row) ? row + 1 : null,

--- a/.github/scripts/static-scan.test.mjs
+++ b/.github/scripts/static-scan.test.mjs
@@ -79,6 +79,26 @@ test("normalizes OSV, actionlint, and zizmor results", () => {
   assert.equal(zizmor[0].blocking, true);
 });
 
+test("normalizes zizmor json-v1 local paths", () => {
+  const findings = parseZizmorReport(
+    [{
+      ident: "zizmor.confused-deputy",
+      desc: "insufficient permissions",
+      determinations: { severity: "Medium" },
+      locations: [{
+        symbolic: {
+          key: { Local: { verbatim_path: "/repo/.github/workflows/release.yml" } },
+        },
+        concrete: { location: { start_point: { row: 2, column: 4 } } },
+      }],
+    }],
+    "/repo",
+  );
+
+  assert.equal(findings[0].path, ".github/workflows/release.yml");
+  assert.equal(findings[0].line, 3);
+});
+
 test("validates plugin structure while accepting a repository-level license", async () => {
   const root = await mkdtemp(join(tmpdir(), "plugin-checks-"));
   const plugin = join(root, "plugins", "sample");


### PR DESCRIPTION
## Summary
- parse zizmor json-v1 local path objects without passing objects to `path.relative`
- read current zizmor `start_point.row` locations while retaining legacy row support
- add a regression test matching the report shape from `paseo-github-workbench`

## Verification
- `npm test` (20 passing)
- `npm run check:scripts`
- `zizmor --no-config --offline .github/workflows`
- parsed the real github-workbench zizmor report: 5 findings, normalized paths and lines