### PR TITLE
Add paseo-monokai-pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Paseo plugins add native workspace panels, composer pills, Command Center items,
 
 *App themes contributed through the plugin API.*
 
-<!-- Add theme plugins here. -->
+- [paseo-monokai-pro](https://github.com/JrDw0/paseo-monokai-pro) - Monokai Pro's Pro, Light, Classic, Machine, Ristretto, Octagon, and Spectrum filter schemes as app themes, with each of the eight palette tokens mapped to a named color from the scheme rather than an approximation, and syntax colors left to Paseo's built-in highlight theme.
 
 ## Daemon and automation
 


### PR DESCRIPTION
## What

Adds **paseo-monokai-pro** to Themes — seven `addTheme` contributions: the Pro, Classic, Machine,
Ristretto, Octagon, and Spectrum filters plus Monokai Pro Light. Client-only: no server entry, no
RPC, no `build` hook.

## Why it belongs

Themes is the one contribution surface with no entry yet. This is the full Monokai Pro family
rather than a single palette — the six dark filters generate from one token table, so the set
tracks the scheme instead of approximating it, and every color is a named token from Wimer Hazell's
published ports (mapping table and sources in the README). MIT licensed.

The README states the plugin API's limits instead of hiding them: syntax colors stay on Paseo's
built-in highlight theme because plugins cannot contribute palettes there, `statusDanger`/diff
tints/shadows are derived by the host, and the light scheme's `accent3` yields 3.03:1 button labels
under Paseo's derived `accentForeground`, with the `accent6` swap that fixes it.

## Install verification

Packaged daemon and client 0.7.2, `pluginsEnabled: true`:

```
$ paseo plugin add JrDw0/paseo-monokai-pro
PLUGIN         STATUS    ENABLED   DIRECTORY
monokai-pro    running   yes       ~/.paseo/plugins/monokai-pro/8b9277c05a08-…/checkout

$ paseo plugin logs monokai-pro
[paseo] Loading plugin
[paseo] Plugin ready

$ paseo plugin update monokai-pro && paseo plugin status monokai-pro
PLUGIN         PREVIOUS        CURRENT         COMMITS   UPDATED
monokai-pro    8b9277c05a08    5d2e78b7d407    1         yes
PLUGIN         SOURCE    CURRENT         LATEST          COMMITS   REF
monokai-pro    git       5d2e78b7d407    5d2e78b7d407    0         main
```

`5d2e78b` is a LICENSE-only follow-up (attribution moved to the README so GitHub detects MIT), so the
install and the update path are both exercised against the tracked `main` branch.

`paseo-plugin.json` carries no `build` key, so the install ran no package manager, install script,
or Git hook; the entry imports only types, so the compiled client bundle has zero runtime imports.
The daemon log records `Loaded plugin` with `methods: []`, which is the expected shape for a
theme-only plugin.

All seven palettes also pass Paseo's own plugin-theme schema (strict hex, names ≤ 60 characters,
monotonic surface ramp), checked by compiling `index.ts` with the plugin compiler and evaluating the
contribution against the collector.

## Scope of verification

Verified on macOS desktop/web at 0.7.2 — plugin load, bundle compile, contribution validation. I
have not run the iOS or Android clients against it, so the entry claims no platform limit; say the
word and I will add or correct a platform note.