### PR TITLE
Add launchd-jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Paseo plugins add native workspace panels, composer pills, Command Center items,
 *Plugins that add daemon-side behavior: schedulers, webhooks, notifications, integrations.*
 
 - [defer](https://github.com/tomgrin10/paseo-defer) - Queues a message for an agent and delivers it after a delay, at a chosen local time, or when the Claude usage window resets, waiting for the session to go idle so the message starts a new turn. Requires Paseo 0.7 or later.
+- [launchd-jobs](https://github.com/gpambrozio/paseo-plugins/tree/main/launchd-jobs) - A sidebar surface that schedules shell commands as LaunchAgents, on a five-field cron expression or a fixed interval, so launchd runs them whether or not Paseo is open. Each job shows what launchd reports, its last twenty runs with durations and exit codes, and the tail of its log. The daemon must run on macOS. Install with `paseo plugin add gpambrozio/paseo-plugins --path launchd-jobs`.
 
 ## Composer and attachments
 


### PR DESCRIPTION
## Plugin

- Name: launchd-jobs
- Repository: https://github.com/gpambrozio/paseo-plugins/tree/main/launchd-jobs (monorepo; this entry is the `launchd-jobs/` directory)

## What it does

A **Scheduled jobs** sidebar surface for running shell commands on a schedule. A job is a name, a
command, an optional working directory, and either a five-field cron expression or a fixed
interval; saving it writes a LaunchAgent to `~/Library/LaunchAgents` and bootstraps it into
`gui/<uid>`. From then on launchd runs it, whether or not Paseo is open.

- **launchd is the scheduler and the store.** The plugin holds no timers and keeps no job database;
  `contribute` returns an empty cleanup. Every refresh reads the plists back, plus `launchctl print`
  per label and `launchctl print-disabled` once. A plist edited by hand is what the list shows.
- **The label prefix is the ownership boundary.** It globs
  `com.paseo-plugins.launchd-jobs.*.plist` and touches nothing else in that directory, so the
  user's own LaunchAgents are never read, rewritten, or booted out.
- **The cron field is explained as you type it** — "At 09:00 on Mon–Fri" — including how many
  `StartCalendarInterval` entries it becomes, since launchd has no expression language and every
  combination is its own entry. Where cron and launchd disagree (day-of-month plus weekday is
  *or* in cron, *and* in launchd) the preview says so.
- **Commands run through `/bin/zsh -lc` with the PATH the login shell reports**, captured at save
  time — the usual reason a LaunchAgent works in the terminal and fails when scheduled.
- Each job shows whether it is running, disabled, or failed, its last twenty runs with durations
  and exit codes, and the tail of its log. Run now, Enable, Disable, Edit, Delete each do the
  `launchctl` part.

## Why it belongs

Paseo already schedules *agents*; this schedules the other half of a developer's automation — the
plain shell commands — from the same app, on the machine the daemon is already on, from a phone as
well as the desktop. It is a front end for launchd rather than a scheduler of its own, so nothing
has to stay running for a job to fire and uninstalling the plugin cannot silently stop the user's
jobs (the README says plainly that removing the plugin leaves the agents installed, and how to
remove them by hand).

The list has no macOS-scheduling entry yet, and the category's existing plugin (`defer`) queues
messages to agents, which is a different job.

### How I verified installation

Daemon and CLI 0.7.1, macOS 15. The plugin ships source only — no build step and no package
manager step on install. Everything it imports at runtime is host-provided (`@getpaseo/plugin`,
`react`, `react-native`, `zod`) plus `node:` builtins and `launchctl`/`plutil` subprocesses in the
server half; `package.json` declares no `preinstall`/`postinstall` and `npm install` is only for
typechecking and the cron tests.

I have been running it as an installed plugin against a 0.7.1 daemon — creating cron and interval
jobs, editing and disabling them, Run now, and reading back the run history and log tail.

Clean install straight from Git, no package manager step:

```
$ paseo plugin add gpambrozio/paseo-plugins --path launchd-jobs --id launchd-jobs-gitcheck
PLUGIN                 STATUS   ENABLED  DIRECTORY
launchd-jobs-gitcheck  running  yes      ~/.paseo/plugins/launchd-jobs-gitcheck/2d325d828bc9-.../checkout/launchd-jobs

$ paseo plugin logs launchd-jobs-gitcheck
stdout  [paseo] Loading plugin
stdout  [paseo] Plugin ready
```

The checkout contains the source files and `package.json` only — no `node_modules`, so nothing was
installed or built. I used `--id` only so the test install would not collide with the copy I develop
against; the default id is `launchd-jobs`. Removed afterwards with `paseo plugin remove`.

### State it reads and changes, for the security note

- Writes, reads, and removes plists under `~/Library/LaunchAgents` whose label starts with
  `com.paseo-plugins.launchd-jobs.` — and only those.
- Runs `launchctl` (`bootstrap`, `bootout`, `kickstart`, `enable`, `disable`, `print`) and `plutil`
  on the daemon machine, in the `gui/<uid>` domain of the user the daemon runs as.
- Runs whatever command the user types, as that user, on launchd's schedule. That is the feature;
  the README states it.
- Writes each job's log and run history plus a slug-to-name map under
  `$PASEO_HOME/plugins/launchd-jobs/`. Logs rotate at 1 MB, history keeps the last 200 runs.
- No network, no credentials, no state outside those two directories.

### Notes on the entry

- Public repo, MIT licensed. The
  [README](https://github.com/gpambrozio/paseo-plugins/tree/main/launchd-jobs) covers what a job is,
  what fires and what does not (Mac asleep, logged out, Paseo closed), what removal does and does
  not do, and a Limitations section.
- **Platform limit stated in the entry: the daemon must run on macOS.** On Linux the plugin loads
  and the surface says so instead of listing jobs; the Paseo *app* can be on any platform, so the
  usual "Web and desktop" phrasing would have been misleading.
- No minimum daemon version: it uses only `addSurface`, `addSidebarItem`, `addCommandCenterItem`,
  and `plugin.handle`, and it is built and run against 0.7.1, the current release. I have not
  tested it on older daemons, so I would rather claim nothing than claim a floor I did not check.
- The entry links the `launchd-jobs/` folder rather than the repo root, since the repo holds three
  plugins, and carries the `--path` install line for the same reason — matching the two entries I
  added earlier. Happy to trim it if you would rather entries stayed to the exact one-line format.

## Checklist

- [x] This pull request adds or updates one plugin.
- [x] I read and followed [CONTRIBUTING.md](https://github.com/omercnet/awesome-paseo-plugins/blob/main/CONTRIBUTING.md).
- [x] I installed it successfully with `paseo plugin add` without install scripts.
- [x] Its README explains behavior, state access, security implications, and known limitations.
- [x] I understand the public plugin source and deterministic scanner findings are sent to the configured model provider for automated security review and contain no secrets, personal information, or confidential material.
- [x] The entry is in the correct category and alphabetical position.
- [x] The entry uses the required format and a factual description ending with a period.
- [x] I noted platform limits and the minimum Paseo daemon version where relevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
