### PR TITLE
docs(themes): add paseo-dracula

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Paseo plugins add native workspace panels, composer pills, Command Center items,
 
 *App themes contributed through the plugin API.*
 
+- [paseo-dracula](https://github.com/omercnet/paseo-dracula) - Dracula Classic app theme using the official palette across Paseo surfaces and derived terminal colors; requires Paseo 0.7.2 or later.
 - [paseo-monokai-pro](https://github.com/JrDw0/paseo-monokai-pro) - Monokai Pro's Pro, Light, Classic, Machine, Ristretto, Octagon, and Spectrum filter schemes as app themes, with each of the eight palette tokens mapped to a named color from the scheme rather than an approximation, and syntax colors left to Paseo's built-in highlight theme.
 
 ## Daemon and automation


### PR DESCRIPTION
## Plugin

- Name: paseo-dracula
- Repository: https://github.com/omercnet/paseo-dracula

## Why it belongs

paseo-dracula provides the official Dracula Classic palette as a minimal, data-only Paseo app theme. It uses every theme seed exposed by the Paseo 0.7.2 plugin API, documents the exact palette mapping and SDK limitations, and adds no surfaces, RPC handlers, filesystem access, process access, or network behavior.

Verified from the public Git repository with `paseo plugin add omercnet/paseo-dracula --id paseo-dracula-git-check`: the plugin reached `running`, and its log completed `Loading plugin` → `Plugin ready`. The temporary verification installation was then removed. The repository's CI and Release Please workflows are green on the listed commit.

## Checklist

- [x] This pull request adds or updates one plugin.
- [x] I read and followed [CONTRIBUTING.md](https://github.com/omercnet/awesome-paseo-plugins/blob/main/CONTRIBUTING.md).
- [x] I installed it successfully with `paseo plugin add` without install scripts.
- [x] Its README explains behavior, state access, security implications, and known limitations.
- [x] I understand the public plugin source and deterministic scanner findings are sent to the configured model provider for automated security review and contain no secrets, personal information, or confidential material.
- [x] The entry is in the correct category and alphabetical position.
- [x] The entry uses the required format and a factual description ending with a period.
- [x] I noted platform limits and the minimum Paseo daemon version where relevant.