### PR TITLE
docs(themes): add Alucard variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Paseo plugins add native workspace panels, composer pills, Command Center items,
 
 *App themes contributed through the plugin API.*
 
-- [paseo-dracula](https://github.com/omercnet/paseo-dracula) - Dracula Classic app theme using the official palette across Paseo surfaces and derived terminal colors; requires Paseo 0.7.2 or later.
+- [paseo-dracula](https://github.com/omercnet/paseo-dracula) - Dracula Classic and Alucard Classic app themes using the official dark and light palettes across Paseo surfaces and derived terminal colors; requires Paseo 0.7.2 or later.
 - [paseo-monokai-pro](https://github.com/JrDw0/paseo-monokai-pro) - Monokai Pro's Pro, Light, Classic, Machine, Ristretto, Octagon, and Spectrum filter schemes as app themes, with each of the eight palette tokens mapped to a named color from the scheme rather than an approximation, and syntax colors left to Paseo's built-in highlight theme.
 
 ## Daemon and automation


### PR DESCRIPTION
## Plugin

- Name: paseo-dracula
- Repository: https://github.com/omercnet/paseo-dracula

## Why it belongs

The listed plugin now implements both variants in the current official Dracula specification: Dracula Classic for dark appearance and Alucard Classic for light appearance. This updates the existing catalog entry without adding another plugin.

Verified both exact theme registrations with Bun tests, loaded both variants in Paseo 0.7.2, captured sanitized Appearance screenshots, and confirmed plugin CI and Release Please are green on commit `499fc2e68d129b66a04163f176e33543131bc5c3`.

## Checklist

- [x] This pull request adds or updates one plugin.
- [x] I read and followed [CONTRIBUTING.md](https://github.com/omercnet/awesome-paseo-plugins/blob/main/CONTRIBUTING.md).
- [x] I installed it successfully with `paseo plugin add` without install scripts.
- [x] Its README explains behavior, state access, security implications, and known limitations.
- [x] I understand the public plugin source and deterministic scanner findings are sent to the configured model provider for automated security review and contain no secrets, personal information, or confidential material.
- [x] The entry is in the correct category and alphabetical position.
- [x] The entry uses the required format and a factual description ending with a period.
- [x] I noted platform limits and the minimum Paseo daemon version where relevant.